### PR TITLE
Upgrade to Wireshark 4.x (Ubuntu 24.04 base + wireshark-dev stable PPA)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jlesage/baseimage-gui:debian-11-v4
+FROM jlesage/baseimage-gui:ubuntu-24.04-v4
 
 ENV DEBIAN_FRONTEND=noninteractive \
     DISPLAY=:1 \
@@ -10,14 +10,19 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 RUN sed -i "s/UI.initSetting('resize', resize);/UI.initSetting('resize', 'remote');/g" /opt/noVNC/app/ui.js
 
-# Preseed wireshark debconf and install dependencies in one layer
+# Preseed wireshark debconf, add the official Wireshark stable PPA
+# (latest 4.x for both amd64 and arm64) and install dependencies in one layer
 RUN echo "wireshark-common wireshark-common/install-setuid boolean false" | debconf-set-selections && \
     apt-get update && \
-    apt-get install -y --no-install-recommends wireshark adwaita-qt curl jq ca-certificates && \
+    apt-get install -y --no-install-recommends software-properties-common curl jq ca-certificates && \
+    add-apt-repository -y ppa:wireshark-dev/stable && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends wireshark adwaita-qt && \
     ARCH=$(dpkg --print-architecture) && \
     LATEST_RELEASE=$(curl -s https://api.github.com/repos/siemens/cshargextcap/releases/latest | jq -r .tag_name) && \
     curl -L -o /tmp/cshargextcap.deb "https://github.com/siemens/cshargextcap/releases/download/${LATEST_RELEASE}/cshargextcap_${LATEST_RELEASE#v}_linux_${ARCH}.deb" && \
-    dpkg -i /tmp/cshargextcap.deb || apt-get -f install -y && \
+    apt-get install -y --no-install-recommends /tmp/cshargextcap.deb && \
+    apt-get purge -y --auto-remove software-properties-common && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/cshargextcap.deb
 


### PR DESCRIPTION
## What

Closes #2.

The image was pinned to Wireshark **3.4.16** because the base image `jlesage/baseimage-gui:debian-11-v4` (Debian 11 / bullseye) only offers Wireshark 3.4.x via apt.

This PR switches the base to **`jlesage/baseimage-gui:ubuntu-24.04-v4`** and installs Wireshark from the official **`ppa:wireshark-dev/stable`** PPA, which publishes the latest stable **4.x** (currently **4.6.6**) for **both `amd64` and `arm64`** — the two platforms this repo's CI builds.

## Changes

- Base image: `debian-11-v4` → `ubuntu-24.04-v4`.
- Add `ppa:wireshark-dev/stable` (via `software-properties-common`, which is then purged) before installing `wireshark`.
- Install `cshargextcap` with `apt-get install <local.deb>` so apt resolves its dependencies, replacing the `dpkg -i … || apt-get -f install` pattern that could silently mask an earlier failed step.
- `adwaita-qt` (Qt dark mode) and the EdgeShark/cshargextcap extcap integration are preserved.

## Verification

No container runtime is available in my local environment, so I could not build the image locally. The repo's `Docker` workflow builds `linux/amd64,linux/arm64` on every PR — that is the end-to-end check for this change. Once green, `Help → About Wireshark` in the container will report 4.6.x, which includes the newer ISIS TLV dissectors mentioned in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)